### PR TITLE
implemented buildUnitSelector

### DIFF
--- a/twSDK.js
+++ b/twSDK.js
@@ -382,6 +382,58 @@ window.twSDK = {
 
         return unitsTable;
     },
+    buildUnitSelector: function (
+        unitsToIgnore,
+        idPrefix,
+        type = 'checkbox'
+    ) {
+        let unitsTable = ``;
+
+        let thUnits = ``;
+        let tableRow = ``;
+
+        let value = ``;
+
+        game_data.units.forEach((unit) => {
+            if (!unitsToIgnore.includes(unit)) {
+                if (type === 'number' || type === 'text') {
+                    value = '0';
+                } else {
+                    value = unit;
+                }
+                thUnits += `
+                    <th class="ra-tac">
+                        <label for="${idPrefix}_unit_${unit}">
+                            <img src="/graphic/unit/unit_${unit}.png" alt="${unit}">
+                        </label>
+                    </th>
+                `;
+
+                tableRow += `
+                    <td class="ra-tac">
+                        <input name="${idPrefix}_chosen_units" type="${type}" id="${idPrefix}_unit_${unit}" data-unit="${unit}" class="${idPrefix}-unit-selector" value="${value}" />
+                    </td>
+                `;
+            }
+        });
+
+        unitsTable = `
+            <table class="ra-table ra-table-v2" width="100%" id="${idPrefix}_unit_selector">
+                <thead>
+                    <tr>
+                        ${thUnits}
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        ${tableRow}
+                    </tr>
+                </tbody>
+            </table>
+        `;
+
+        return unitsTable;
+    },
     calculateCoinsNeededForNthNoble: function (noble) {
         return (noble * noble + noble) / 2;
     },


### PR DESCRIPTION
Implemented new more generic function to create unit selection/pick tables.
param {Array} unitsToIgnore - An array of unit names to be ignored in the generation.
param {string} idPrefix - A prefix to be used in generating unique IDs for HTML elements.
param {string} [type='checkbox'] - The type of input elements to generate (checkbox, radio, number, or text).
returns {string} - The generated HTML table for unit selection.

Supports useful input types like checkbox, radio, number, or text and due to idPrefix allows for multiple tables to be generated with different IDs. This could replace buildUnitsPicker but since buildUnitSelector doesnt include initialization options for checking checkboxes initialization has to be done after creating the table.

Order of functions may need to be changed to keep alphabetical order.