### PR TITLE
implemented getLastCoordFromString

### DIFF
--- a/twSDK.js
+++ b/twSDK.js
@@ -990,6 +990,16 @@ window.twSDK = {
         );
         return arrivalDateTime;
     },
+    getLastCoordFromString: function (string) {
+        if (!string) return [];
+        const regex = this.coordsRegex;
+        let match;
+        let lastMatch;
+        while ((match = regex.exec(string)) !== null) {
+            lastMatch = match;
+        }
+        return lastMatch ? lastMatch[0] : [];
+    },
     getPagesToFetch: function () {
         let list_pages = [];
 


### PR DESCRIPTION
Implemented a new function to get the last coordinate in a given string. This is useful for getting the coordinate from a player village name without accidentally confusing some parts of the village name for a coordinate  (for example "44|29|43 Village (493|424) K44").

param {string} string - The input string from which to extract the coordinate substring.
returns {string[]} Returns an array containing the last coordinate substring found in the input string.

This can replace getCoordFromString as I dont see any reason one would want the first occurance of a coordinate but I added it as a new function to preserve compatibility with existing scripts.